### PR TITLE
GGResourceSet 클래스를 사용하여 리소스 관리 시스템 추가

### DIFF
--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Abilities/GGGameplayAbility.cpp
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Abilities/GGGameplayAbility.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "AbilitySystem/Abilities/GGGameplayAbility.h"
+

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Attributes/GGResourceSet.cpp
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Attributes/GGResourceSet.cpp
@@ -1,0 +1,5 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "AbilitySystem/Attributes/GGResourceSet.h"
+

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Attributes/GGResourceSet.cpp
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Attributes/GGResourceSet.cpp
@@ -8,9 +8,9 @@
 
 UGGResourceSet::UGGResourceSet()
 	: Mana(100.0f)
-	, MaxMana(100.0f)
-	, Stamina(100.0f)
-	, MaxStamina(100.0f)
+	  , MaxMana(100.0f)
+	  , Stamina(100.0f)
+	  , MaxStamina(100.0f)
 {
 }
 
@@ -27,21 +27,49 @@ void UGGResourceSet::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLi
 void UGGResourceSet::OnRep_Mana(const FGameplayAttributeData& OldValue)
 {
 	GAMEPLAYATTRIBUTE_REPNOTIFY(UGGResourceSet, Mana, OldValue);
+
+	const float CurrentMana = GetMana();
+	const float EstimatedMagnitude = CurrentMana - OldValue.GetCurrentValue();
+
+	OnManaChanged.Broadcast(nullptr, nullptr, nullptr, EstimatedMagnitude, OldValue.GetCurrentValue(), CurrentMana);
+
+	if (!bOutOfMana && CurrentMana <= 0.0f)
+	{
+		OnOutOfMana.Broadcast(nullptr, nullptr, nullptr, EstimatedMagnitude, OldValue.GetCurrentValue(), CurrentMana);
+	}
+	
+	bOutOfMana = (CurrentMana <= 0.0f);
 }
 
 void UGGResourceSet::OnRep_MaxMana(const FGameplayAttributeData& OldValue)
 {
 	GAMEPLAYATTRIBUTE_REPNOTIFY(UGGResourceSet, MaxMana, OldValue);
+
+	OnMaxManaChanged.Broadcast(nullptr, nullptr, nullptr, GetMaxMana() - OldValue.GetCurrentValue(), OldValue.GetCurrentValue(), GetMaxMana());
 }
 
 void UGGResourceSet::OnRep_Stamina(const FGameplayAttributeData& OldValue)
 {
 	GAMEPLAYATTRIBUTE_REPNOTIFY(UGGResourceSet, Stamina, OldValue);
+
+	const float CurrentStamina = GetStamina();
+	const float EstimatedMagnitude = CurrentStamina - OldValue.GetCurrentValue();
+
+	OnStaminaChanged.Broadcast(nullptr, nullptr, nullptr, EstimatedMagnitude, OldValue.GetCurrentValue(), CurrentStamina);
+
+	if (!bOutOfStamina && CurrentStamina <= 0.0f)
+	{
+		OnOutOfStamina.Broadcast(nullptr, nullptr, nullptr, EstimatedMagnitude, OldValue.GetCurrentValue(), CurrentStamina);
+	}
+	
+	bOutOfStamina = (CurrentStamina <= 0.0f);
 }
 
 void UGGResourceSet::OnRep_MaxStamina(const FGameplayAttributeData& OldValue)
 {
 	GAMEPLAYATTRIBUTE_REPNOTIFY(UGGResourceSet, MaxStamina, OldValue);
+
+	OnMaxStaminaChanged.Broadcast(nullptr, nullptr, nullptr, GetMaxStamina() - OldValue.GetCurrentValue(), OldValue.GetCurrentValue(), GetMaxStamina());
 }
 
 bool UGGResourceSet::PreGameplayEffectExecute(FGameplayEffectModCallbackData& Data)

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Attributes/GGResourceSet.cpp
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Attributes/GGResourceSet.cpp
@@ -3,3 +3,111 @@
 
 #include "AbilitySystem/Attributes/GGResourceSet.h"
 
+#include "AbilitySystem/LyraAbilitySystemComponent.h"
+#include "Net/UnrealNetwork.h"
+
+UGGResourceSet::UGGResourceSet()
+	: Mana(100.0f)
+	, MaxMana(100.0f)
+	, Stamina(100.0f)
+	, MaxStamina(100.0f)
+{
+}
+
+void UGGResourceSet::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGResourceSet, Mana, COND_None, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGResourceSet, MaxMana, COND_None, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGResourceSet, Stamina, COND_None, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGResourceSet, MaxStamina, COND_None, REPNOTIFY_Always);
+}
+
+void UGGResourceSet::OnRep_Mana(const FGameplayAttributeData& OldValue)
+{
+	GAMEPLAYATTRIBUTE_REPNOTIFY(UGGResourceSet, Mana, OldValue);
+}
+
+void UGGResourceSet::OnRep_MaxMana(const FGameplayAttributeData& OldValue)
+{
+	GAMEPLAYATTRIBUTE_REPNOTIFY(UGGResourceSet, MaxMana, OldValue);
+}
+
+void UGGResourceSet::OnRep_Stamina(const FGameplayAttributeData& OldValue)
+{
+	GAMEPLAYATTRIBUTE_REPNOTIFY(UGGResourceSet, Stamina, OldValue);
+}
+
+void UGGResourceSet::OnRep_MaxStamina(const FGameplayAttributeData& OldValue)
+{
+	GAMEPLAYATTRIBUTE_REPNOTIFY(UGGResourceSet, MaxStamina, OldValue);
+}
+
+bool UGGResourceSet::PreGameplayEffectExecute(FGameplayEffectModCallbackData& Data)
+{
+	return Super::PreGameplayEffectExecute(Data);
+}
+
+void UGGResourceSet::PostGameplayEffectExecute(const FGameplayEffectModCallbackData& Data)
+{
+	Super::PostGameplayEffectExecute(Data);
+}
+
+void UGGResourceSet::PreAttributeBaseChange(const FGameplayAttribute& Attribute, float& NewValue) const
+{
+	Super::PreAttributeBaseChange(Attribute, NewValue);
+
+	ClampAttribute(Attribute, NewValue);
+}
+
+void UGGResourceSet::PreAttributeChange(const FGameplayAttribute& Attribute, float& NewValue)
+{
+	Super::PreAttributeChange(Attribute, NewValue);
+
+	ClampAttribute(Attribute, NewValue);
+}
+
+void UGGResourceSet::PostAttributeChange(const FGameplayAttribute& Attribute, float OldValue, float NewValue)
+{
+	Super::PostAttributeChange(Attribute, OldValue, NewValue);
+
+	if (Attribute == GetMaxManaAttribute())
+	{
+		if (GetMana() > NewValue)
+		{
+			ULyraAbilitySystemComponent* ASC = GetLyraAbilitySystemComponent();
+			check(ASC);
+			ASC->ApplyModToAttribute(GetManaAttribute(), EGameplayModOp::Override, NewValue);
+		}
+	}
+	else if (Attribute == GetMaxStaminaAttribute())
+	{
+		if (GetStamina() > NewValue)
+		{
+			ULyraAbilitySystemComponent* ASC = GetLyraAbilitySystemComponent();
+			check(ASC);
+			ASC->ApplyModToAttribute(GetStaminaAttribute(), EGameplayModOp::Override, NewValue);
+		}
+	}
+}
+
+void UGGResourceSet::ClampAttribute(const FGameplayAttribute& Attribute, float& NewValue) const
+{
+	if (Attribute == GetManaAttribute())
+	{
+		NewValue = FMath::Clamp(NewValue, 0.0f, GetMaxMana());
+	}
+	else if (Attribute == GetMaxManaAttribute())
+	{
+		NewValue = FMath::Max(NewValue, 1.0f);
+	}
+	else if (Attribute == GetStaminaAttribute())
+	{
+		NewValue = FMath::Clamp(NewValue, 0.0f, GetMaxStamina());
+	}
+	else if (Attribute == GetMaxStaminaAttribute())
+	{
+		NewValue = FMath::Max(NewValue, 1.0f);
+	}
+}

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/Player/GGPlayerState.cpp
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/Player/GGPlayerState.cpp
@@ -3,3 +3,10 @@
 
 #include "Player/GGPlayerState.h"
 
+#include "AbilitySystem/Attributes/GGResourceSet.h"
+
+AGGPlayerState::AGGPlayerState(const FObjectInitializer& ObjectInitializer)
+	: Super(ObjectInitializer)
+{
+	ResourceSet = CreateDefaultSubobject<UGGResourceSet>(TEXT("ResourceSet"));
+}

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/AbilitySystem/Abilities/GGGameplayAbility.h
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/AbilitySystem/Abilities/GGGameplayAbility.h
@@ -1,0 +1,17 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "AbilitySystem/Abilities/LyraGameplayAbility.h"
+#include "GGGameplayAbility.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class GGCORERUNTIME_API UGGGameplayAbility : public ULyraGameplayAbility
+{
+	GENERATED_BODY()
+	
+};

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/AbilitySystem/Attributes/GGResourceSet.h
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/AbilitySystem/Attributes/GGResourceSet.h
@@ -2,16 +2,72 @@
 
 #pragma once
 
-#include "CoreMinimal.h"
+#include "AbilitySystemComponent.h"
 #include "AbilitySystem/Attributes/LyraAttributeSet.h"
+
 #include "GGResourceSet.generated.h"
 
 /**
  * 
  */
-UCLASS()
+UCLASS(BlueprintType)
 class GGCORERUNTIME_API UGGResourceSet : public ULyraAttributeSet
 {
 	GENERATED_BODY()
+
+public:
+
+	UGGResourceSet();
+
+	ATTRIBUTE_ACCESSORS(UGGResourceSet, Mana);
+	ATTRIBUTE_ACCESSORS(UGGResourceSet, MaxMana);
+	ATTRIBUTE_ACCESSORS(UGGResourceSet, Stamina);
+	ATTRIBUTE_ACCESSORS(UGGResourceSet, MaxStamina);
+
+	mutable FLyraAttributeEvent OnManaChanged;
+	mutable FLyraAttributeEvent OnMaxManaChanged;
 	
+	mutable FLyraAttributeEvent OnStaminaChanged;
+	mutable FLyraAttributeEvent OnMaxStaminaChanged;
+	
+	mutable FLyraAttributeEvent OnOutOfMana;
+	mutable FLyraAttributeEvent OnOutOfStamina;
+
+protected:
+
+	UFUNCTION()
+	void OnRep_Mana(const FGameplayAttributeData& OldValue);
+
+	UFUNCTION()
+	void OnRep_MaxMana(const FGameplayAttributeData& OldValue);
+
+	UFUNCTION()
+	void OnRep_Stamina(const FGameplayAttributeData& OldValue);
+
+	UFUNCTION()
+	void OnRep_MaxStamina(const FGameplayAttributeData& OldValue);
+
+	virtual bool PreGameplayEffectExecute(FGameplayEffectModCallbackData& Data) override;
+	virtual void PostGameplayEffectExecute(const FGameplayEffectModCallbackData& Data) override;
+
+	virtual void PreAttributeBaseChange(const FGameplayAttribute& Attribute, float& NewValue) const override;
+	virtual void PreAttributeChange(const FGameplayAttribute& Attribute, float& NewValue) override;
+	virtual void PostAttributeChange(const FGameplayAttribute& Attribute, float OldValue, float NewValue) override;
+
+	void ClampAttribute(const FGameplayAttribute& Attribute, float& NewValue) const;
+	
+private:
+
+	UPROPERTY(BlueprintReadOnly, ReplicatedUsing = OnRep_Mana, Category = "GG|Resource", Meta = (AllowPrivateAccess = true))
+	FGameplayAttributeData Mana;
+
+	UPROPERTY(BlueprintReadOnly, ReplicatedUsing = OnRep_MaxMana, Category = "GG|Resource", Meta = (AllowPrivateAccess = true))
+	FGameplayAttributeData MaxMana;
+
+	UPROPERTY(BlueprintReadOnly, ReplicatedUsing = OnRep_Stamina, Category = "GG|Resource", Meta = (AllowPrivateAccess = true))
+	FGameplayAttributeData Stamina;
+
+	UPROPERTY(BlueprintReadOnly, ReplicatedUsing = OnRep_MaxStamina, Category = "GG|Resource", Meta = (AllowPrivateAccess = true))
+	FGameplayAttributeData MaxStamina;
+
 };

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/AbilitySystem/Attributes/GGResourceSet.h
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/AbilitySystem/Attributes/GGResourceSet.h
@@ -1,0 +1,17 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "AbilitySystem/Attributes/LyraAttributeSet.h"
+#include "GGResourceSet.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class GGCORERUNTIME_API UGGResourceSet : public ULyraAttributeSet
+{
+	GENERATED_BODY()
+	
+};

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/AbilitySystem/Attributes/GGResourceSet.h
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/AbilitySystem/Attributes/GGResourceSet.h
@@ -70,4 +70,12 @@ private:
 	UPROPERTY(BlueprintReadOnly, ReplicatedUsing = OnRep_MaxStamina, Category = "GG|Resource", Meta = (AllowPrivateAccess = true))
 	FGameplayAttributeData MaxStamina;
 
+	bool bOutOfMana;
+	bool bOutOfStamina;
+
+	float MaxManaBeforeAttributeChange;
+	float ManaBeforeAttributeChange;
+	float MaxStaminaBeforeAttributeChange;
+	float StaminaBeforeAttributeChange;
+
 };

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/AbilitySystem/Attributes/GGResourceSet.h
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/AbilitySystem/Attributes/GGResourceSet.h
@@ -23,6 +23,10 @@ public:
 	ATTRIBUTE_ACCESSORS(UGGResourceSet, MaxMana);
 	ATTRIBUTE_ACCESSORS(UGGResourceSet, Stamina);
 	ATTRIBUTE_ACCESSORS(UGGResourceSet, MaxStamina);
+	ATTRIBUTE_ACCESSORS(UGGResourceSet, ManaCost);
+	ATTRIBUTE_ACCESSORS(UGGResourceSet, ManaGain);
+	ATTRIBUTE_ACCESSORS(UGGResourceSet, StaminaCost);
+	ATTRIBUTE_ACCESSORS(UGGResourceSet, StaminaGain);
 
 	mutable FLyraAttributeEvent OnManaChanged;
 	mutable FLyraAttributeEvent OnMaxManaChanged;
@@ -77,5 +81,17 @@ private:
 	float ManaBeforeAttributeChange;
 	float MaxStaminaBeforeAttributeChange;
 	float StaminaBeforeAttributeChange;
+
+	UPROPERTY(BlueprintReadOnly, Category = "GG|Resource", Meta = (AllowPrivateAccess = true))
+	FGameplayAttributeData ManaCost;
+
+	UPROPERTY(BlueprintReadOnly, Category = "GG|Resource", Meta = (AllowPrivateAccess = true))
+	FGameplayAttributeData ManaGain;
+
+	UPROPERTY(BlueprintReadOnly, Category = "GG|Resource", Meta = (AllowPrivateAccess = true))
+	FGameplayAttributeData StaminaCost;
+
+	UPROPERTY(BlueprintReadOnly, Category = "GG|Resource", Meta = (AllowPrivateAccess = true))
+	FGameplayAttributeData StaminaGain;
 
 };

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/Player/GGPlayerState.h
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/Player/GGPlayerState.h
@@ -13,5 +13,14 @@ UCLASS()
 class GGCORERUNTIME_API AGGPlayerState : public ALyraPlayerState
 {
 	GENERATED_BODY()
-	
+
+public:
+
+	AGGPlayerState(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
+
+private:
+
+	UPROPERTY()
+	TObjectPtr<const class UGGResourceSet> ResourceSet;
+
 };


### PR DESCRIPTION
### 설명

이 풀 리퀘스트는 `GGResourceSet` 클래스를 활용한 리소스 관리 시스템을 도입합니다. 주요 변경 사항 및 추가 내용은 다음과 같습니다:

* 리소스 소모(`ManaCost`, `StaminaCost`) 및 회복(`ManaGain`, `StaminaGain`) 메커니즘 구현.
* 리소스 변화(`OnManaChanged`, `OnStaminaChanged`) 및 고갈(`OnOutOfMana`, `OnOutOfStamina`)에 대한 이벤트 브로드캐스팅 추가.
* 리소스 처리를 개선하기 위해 `UGGGameplayAbility`와 `GGResourceSet`을 확장하여 어빌리티 시스템 강화.
* `GGPlayerState`에서 리소스(`Mana`, `MaxMana`, `Stamina`, `MaxStamina`) 초기화 및 관리.