### PR TITLE
속성 복제 조건을 변경하여 동기화를 개선

### DIFF
--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Attributes/GGDefenseSet.cpp
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Attributes/GGDefenseSet.cpp
@@ -16,9 +16,9 @@ void UGGDefenseSet::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLif
 {
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
-	DOREPLIFETIME_CONDITION_NOTIFY(UGGDefenseSet, PhysicalDamageReduction, COND_OwnerOnly, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UGGDefenseSet, MagicDamageReduction, COND_OwnerOnly, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UGGDefenseSet, FlatDamageReduction, COND_OwnerOnly, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGDefenseSet, PhysicalDamageReduction, COND_None, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGDefenseSet, MagicDamageReduction, COND_None, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGDefenseSet, FlatDamageReduction, COND_None, REPNOTIFY_Always);
 }
 
 void UGGDefenseSet::OnRep_PhysicalDamageReduction(const FGameplayAttributeData& OldValue)

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Attributes/GGOffenseSet.cpp
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Attributes/GGOffenseSet.cpp
@@ -23,13 +23,12 @@ void UGGOffenseSet::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLif
 
 	DOREPLIFETIME_CONDITION_NOTIFY(UGGOffenseSet, AttackSpeed, COND_None, REPNOTIFY_Always);
 	DOREPLIFETIME_CONDITION_NOTIFY(UGGOffenseSet, CastSpeed, COND_None, REPNOTIFY_Always);
-
-	DOREPLIFETIME_CONDITION_NOTIFY(UGGOffenseSet, CritChance, COND_OwnerOnly, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UGGOffenseSet, CritDamage, COND_OwnerOnly, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UGGOffenseSet, PhysicalDamageAmp, COND_OwnerOnly, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UGGOffenseSet, MagicDamageAmp, COND_OwnerOnly, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UGGOffenseSet, PhysicalPenetration, COND_OwnerOnly, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UGGOffenseSet, MagicPenetration, COND_OwnerOnly, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGOffenseSet, CritChance, COND_None, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGOffenseSet, CritDamage, COND_None, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGOffenseSet, PhysicalDamageAmp, COND_None, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGOffenseSet, MagicDamageAmp, COND_None, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGOffenseSet, PhysicalPenetration, COND_None, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGOffenseSet, MagicPenetration, COND_None, REPNOTIFY_Always);
 }
 
 void UGGOffenseSet::OnRep_CritChance(const FGameplayAttributeData& OldValue)

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Attributes/GGUtilitySet.cpp
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Attributes/GGUtilitySet.cpp
@@ -24,16 +24,15 @@ void UGGUtilitySet::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLif
 	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
 
 	DOREPLIFETIME_CONDITION_NOTIFY(UGGUtilitySet, MoveSpeed, COND_None, REPNOTIFY_Always);
-
-	DOREPLIFETIME_CONDITION_NOTIFY(UGGUtilitySet, StaminaRegen, COND_OwnerOnly, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UGGUtilitySet, StaminaRegenPercent, COND_OwnerOnly, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UGGUtilitySet, ManaRegen, COND_OwnerOnly, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UGGUtilitySet, ManaRegenPercent, COND_OwnerOnly, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UGGUtilitySet, HealthRegen, COND_OwnerOnly, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UGGUtilitySet, HealthRegenPercent, COND_OwnerOnly, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UGGUtilitySet, CooldownReduction, COND_OwnerOnly, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UGGUtilitySet, PhysicalDamageAbsorption, COND_OwnerOnly, REPNOTIFY_Always);
-	DOREPLIFETIME_CONDITION_NOTIFY(UGGUtilitySet, MagicDamageAbsorption, COND_OwnerOnly, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGUtilitySet, StaminaRegen, COND_None, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGUtilitySet, StaminaRegenPercent, COND_None, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGUtilitySet, ManaRegen, COND_None, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGUtilitySet, ManaRegenPercent, COND_None, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGUtilitySet, HealthRegen, COND_None, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGUtilitySet, HealthRegenPercent, COND_None, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGUtilitySet, CooldownReduction, COND_None, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGUtilitySet, PhysicalDamageAbsorption, COND_None, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGUtilitySet, MagicDamageAbsorption, COND_None, REPNOTIFY_Always);
 }
 
 void UGGUtilitySet::OnRep_StaminaRegen(const FGameplayAttributeData& OldValue)


### PR DESCRIPTION
### 설명

이 풀 리퀘스트는 서버와 클라이언트 간의 동기화를 개선하기 위해 다양한 Attribute Set의 복제 조건을 업데이트합니다.

#### 변경 사항:

* `GGDefenseSet`의 복제 조건을 `COND_OwnerOnly`에서 `COND_None`으로 변경.
* `GGUtilitySet`의 복제 조건을 `COND_OwnerOnly`에서 `COND_None`으로 변경.
* `GGOffenseSet`의 복제 조건을 `COND_OwnerOnly`에서 `COND_None`으로 변경.
* 모든 Attribute 변경 사항이 항상 클라이언트와 동기화되도록 보장.