### PR TITLE
테스트 스킬 데이터 및 퀵바 슬롯 쿨다운 로직 수정

### DIFF
--- a/Plugins/GameFeatures/GGCore/Content/Skills/Test/DA_GGTest.uasset
+++ b/Plugins/GameFeatures/GGCore/Content/Skills/Test/DA_GGTest.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ba94798725cca7240965387465faf533d9ef2437d2f8cf91b21b9ccf3d17652c
-size 2388
+oid sha256:376fbaa7fae0d12dd8c27dbfc42bd6b22c1f08e6b039313dad93c2a722ae5e50
+size 3420

--- a/Plugins/GameFeatures/GGCore/Content/Skills/Test/GA_GGTest.uasset
+++ b/Plugins/GameFeatures/GGCore/Content/Skills/Test/GA_GGTest.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0f3a3a1d2150c4d92ae43e7882ff2a9f273d35c8da883e28ad0cbe397b64538d
-size 62465
+oid sha256:65a819bf7c17e8457a8a78f59808d72d5896de8e9222a0d10fccf1f211657513
+size 65475

--- a/Plugins/GameFeatures/GGCore/Content/UserInterface/HUD/W_GG_QuickBarSlot.uasset
+++ b/Plugins/GameFeatures/GGCore/Content/UserInterface/HUD/W_GG_QuickBarSlot.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:23b2350a73c05c956f07e3f4228430ef3cf314e3f2185f0e6f2a842132bc8864
-size 336265
+oid sha256:92629dded18cbddfbc3a14c11eec489ce70650a5ec8a1a92bcf93c9b334eaab8
+size 386494


### PR DESCRIPTION

**HUD의 기본 바 위젯에 마나, 스태미나 소모 적용되는 지 확인하기 위해 수정**
GA_GGTest
- CommitAbilityCost 추가해서 이펙트 Cost 적용
DA_GGTest
- 스킬 사용시 HUD 기본 바 위젯에 Cost 소모 적용되는 지 확인

**동적으로 쿨다운을 계산하고 아이콘에 적용할 수 있도록 로직 수정**
W_GG_QuickBarSlot
- 퀵바 슬롯 UI 쿨다운 로직 수정
- 이전 로직: 스킬 데이터의 재사용 대기시간 그대로 사용
- 변경된 로직: 쿨다운 태그로 이펙트를 찾아 Total Duration, Remaining Duration를 가져와서 쿨다운 퍼센트 계산