### PR TITLE
카메라 위치 및 이동 애니메이션 추가

### DIFF
--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/Camera/GGCameraMode_FirstPerson.cpp
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/Camera/GGCameraMode_FirstPerson.cpp
@@ -14,8 +14,6 @@ UGGCameraMode_FirstPerson::UGGCameraMode_FirstPerson()
 
 void UGGCameraMode_FirstPerson::UpdateView(float DeltaTime)
 {
-	Super::UpdateView(DeltaTime);
-
 	ACharacter* CharacterOwner = Cast<ACharacter>(GetTargetActor());
 	if (!CharacterOwner) return;
 
@@ -37,6 +35,10 @@ void UGGCameraMode_FirstPerson::UpdateView(float DeltaTime)
 		{
 			View.Location = TargetLocation;
 		}
+	}
+	else
+	{
+		Super::UpdateView(DeltaTime);
 	}
 	
 	if (!ViewOffset.IsZero())

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/Camera/GGCameraMode_FirstPerson.cpp
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/Camera/GGCameraMode_FirstPerson.cpp
@@ -2,6 +2,8 @@
 
 
 #include "Camera/GGCameraMode_FirstPerson.h"
+#include "GameFramework/Character.h"
+#include "Components/SkeletalMeshComponent.h"
 
 UGGCameraMode_FirstPerson::UGGCameraMode_FirstPerson()
 {
@@ -14,11 +16,33 @@ void UGGCameraMode_FirstPerson::UpdateView(float DeltaTime)
 {
 	Super::UpdateView(DeltaTime);
 
+	ACharacter* CharacterOwner = Cast<ACharacter>(GetTargetActor());
+	if (!CharacterOwner) return;
+
+	USkeletalMeshComponent* Mesh = CharacterOwner->GetMesh();
+	if (!Mesh) return;
+	
+	
+	if (Mesh->DoesSocketExist(CameraSocketName))
+	{
+		const FTransform SocketTransform = Mesh->GetSocketTransform(CameraSocketName, RTS_World);
+		const FVector TargetLocation = SocketTransform.GetLocation();
+
+		if (bEnablePositionLag)
+		{
+			//카메라 보정함수
+			View.Location = FMath::VInterpTo(View.Location, TargetLocation, DeltaTime, PositionLag);
+		}
+		else
+		{
+			View.Location = TargetLocation;
+		}
+	}
+	
 	if (!ViewOffset.IsZero())
 	{
-		const FRotator ViewRotation = GetCameraModeView().Rotation;
-		View.Location += ViewRotation.RotateVector(ViewOffset);
-	}
+		View.Location += View.Rotation.RotateVector(ViewOffset);
+	} 
 }
 
 FVector UGGCameraMode_FirstPerson::GetPivotLocation() const

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/Camera/GGCameraMode_FirstPerson.h
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/Camera/GGCameraMode_FirstPerson.h
@@ -28,4 +28,17 @@ protected:
 	// 피벗 위치를 조정하기 위한 변수입니다. 캐릭터의 기본 눈 위치를 기준으로 합니다.
 	UPROPERTY(EditDefaultsOnly, Category = "First Person")
 	FVector PivotOffset;
+
+	// 카메라 보정 값
+	UPROPERTY(EditDefaultsOnly, Category="First Person", meta=(ClampMin="0.0", UIMin="0.0", ToolTip="위치 보정 속도. 0이면 즉시 이동"))
+	float PositionLag = 20.f;
+
+	// 카메라를 붙일 소켓 이름
+	UPROPERTY(EditDefaultsOnly, Category="First Person")
+	FName CameraSocketName = TEXT("CameraSocket");
+
+	// 카메라 보정 활성화
+	UPROPERTY(EditDefaultsOnly, Category="First Person")
+	bool bEnablePositionLag = true;
+	
 };


### PR DESCRIPTION
카메라 개선 :
1인칭 카메라를 캐릭터 소켓 위치에 부드럽게 맞추는 기능을 추가
 - `PositionLag` 변수와 `bEnablePostionLag`을 프로퍼티로 추가해 에디터 내에서 수정가능
 - `CameraSocketName`을 프로퍼티로 추가해 에디터 내에서 카메라가 붙을 소켓 수정가능

캐릭터 애니메이션은 오래전 커밋으로 무시해 주십숑
