### PR TITLE
ShieldSet 추가 및 방어막 피해 로직 개선

### DIFF
--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Attributes/GGShieldSet.cpp
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Attributes/GGShieldSet.cpp
@@ -53,6 +53,11 @@ void UGGShieldSet::PostGameplayEffectExecute(const FGameplayEffectModCallbackDat
 		SetShield(FMath::Max(0.0f, GetShield() - GetShieldDamage()));
 		SetShieldDamage(0.0f);
 	}
+	else if (Data.EvaluatedData.Attribute == GetShieldHealingAttribute())
+	{
+		SetShield(FMath::Max(0.0f, GetShield() + GetShieldHealing()));
+		SetShieldHealing(0.0f);
+	}
 	else if (Data.EvaluatedData.Attribute == GetShieldAttribute())
 	{
 		SetShield(FMath::Max(0.0f, GetShield()));

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Attributes/GGShieldSet.cpp
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Attributes/GGShieldSet.cpp
@@ -1,0 +1,47 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "AbilitySystem/Attributes/GGShieldSet.h"
+
+UGGShieldSet::UGGShieldSet()
+	: Shield(0.0f)
+	, MaxShield(0.0f)
+{
+}
+
+void UGGShieldSet::OnRep_Shield(const FGameplayAttributeData& OldValue)
+{
+}
+
+void UGGShieldSet::OnRep_MaxShield(const FGameplayAttributeData& OldValue)
+{
+}
+
+bool UGGShieldSet::PreGameplayEffectExecute(FGameplayEffectModCallbackData& Data)
+{
+	return Super::PreGameplayEffectExecute(Data);
+}
+
+void UGGShieldSet::PostGameplayEffectExecute(const FGameplayEffectModCallbackData& Data)
+{
+	Super::PostGameplayEffectExecute(Data);
+}
+
+void UGGShieldSet::PreAttributeBaseChange(const FGameplayAttribute& Attribute, float& NewValue) const
+{
+	Super::PreAttributeBaseChange(Attribute, NewValue);
+}
+
+void UGGShieldSet::PreAttributeChange(const FGameplayAttribute& Attribute, float& NewValue)
+{
+	Super::PreAttributeChange(Attribute, NewValue);
+}
+
+void UGGShieldSet::PostAttributeChange(const FGameplayAttribute& Attribute, float OldValue, float NewValue)
+{
+	Super::PostAttributeChange(Attribute, OldValue, NewValue);
+}
+
+void UGGShieldSet::ClampAttribute(const FGameplayAttribute& Attribute, float& NewValue) const
+{
+}

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Attributes/GGShieldSet.cpp
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Attributes/GGShieldSet.cpp
@@ -3,45 +3,115 @@
 
 #include "AbilitySystem/Attributes/GGShieldSet.h"
 
+#include "GameplayEffectExtension.h"
+#include "AbilitySystem/LyraAbilitySystemComponent.h"
+#include "Net/UnrealNetwork.h"
+
 UGGShieldSet::UGGShieldSet()
 	: Shield(0.0f)
 	, MaxShield(0.0f)
 {
+	ShieldBeforeAttributeChange = 0.0f;
+	MaxShieldBeforeAttributeChange = 0.0f;
+}
+
+void UGGShieldSet::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGShieldSet, Shield, COND_None, REPNOTIFY_Always);
+	DOREPLIFETIME_CONDITION_NOTIFY(UGGShieldSet, MaxShield, COND_None, REPNOTIFY_Always);
 }
 
 void UGGShieldSet::OnRep_Shield(const FGameplayAttributeData& OldValue)
 {
+	GAMEPLAYATTRIBUTE_REPNOTIFY(UGGShieldSet, Shield, OldValue);
+
+	OnShieldChanged.Broadcast(nullptr, nullptr, nullptr, GetShield() - OldValue.GetCurrentValue(),
+	                          OldValue.GetCurrentValue(), GetShield());
 }
 
 void UGGShieldSet::OnRep_MaxShield(const FGameplayAttributeData& OldValue)
 {
+	GAMEPLAYATTRIBUTE_REPNOTIFY(UGGShieldSet, MaxShield, OldValue);
+
+	OnMaxShieldChanged.Broadcast(nullptr, nullptr, nullptr, GetMaxShield() - OldValue.GetCurrentValue(),
+	                             OldValue.GetCurrentValue(), GetMaxShield());
 }
 
 bool UGGShieldSet::PreGameplayEffectExecute(FGameplayEffectModCallbackData& Data)
 {
-	return Super::PreGameplayEffectExecute(Data);
+	if (!Super::PreGameplayEffectExecute(Data))
+	{
+		return false;
+	}
+
+	ShieldBeforeAttributeChange = GetShield();
+	MaxShieldBeforeAttributeChange = GetMaxShield();
+
+	return true;
 }
 
 void UGGShieldSet::PostGameplayEffectExecute(const FGameplayEffectModCallbackData& Data)
 {
 	Super::PostGameplayEffectExecute(Data);
-}
 
-void UGGShieldSet::PreAttributeBaseChange(const FGameplayAttribute& Attribute, float& NewValue) const
-{
-	Super::PreAttributeBaseChange(Attribute, NewValue);
+	const FGameplayEffectContextHandle& EffectContext = Data.EffectSpec.GetEffectContext();
+	AActor* Instigator = EffectContext.GetOriginalInstigator();
+	AActor* Causer = EffectContext.GetEffectCauser();
+
+	if (Data.EvaluatedData.Attribute == GetShieldDamageAttribute())
+	{
+		SetShield(FMath::Clamp(GetShield() - GetShieldDamage(), 0.0f, GetMaxShield()));
+		SetShieldDamage(0.0f);
+	}
+	else if (Data.EvaluatedData.Attribute == GetShieldAttribute())
+	{
+		SetShield(FMath::Clamp(GetShield(), 0.0f, GetMaxShield()));
+	}
+	else if (Data.EvaluatedData.Attribute == GetMaxShieldAttribute())
+	{
+		OnMaxShieldChanged.Broadcast(Instigator, Causer, &Data.EffectSpec, Data.EvaluatedData.Magnitude,
+		                             MaxShieldBeforeAttributeChange, GetMaxShield());
+	}
+
+	if (GetShield() != ShieldBeforeAttributeChange)
+	{
+		OnShieldChanged.Broadcast(Instigator, Causer, &Data.EffectSpec, Data.EvaluatedData.Magnitude,
+		                          ShieldBeforeAttributeChange, GetShield());
+	}
 }
 
 void UGGShieldSet::PreAttributeChange(const FGameplayAttribute& Attribute, float& NewValue)
 {
 	Super::PreAttributeChange(Attribute, NewValue);
+
+	ClampAttribute(Attribute, NewValue);
 }
 
 void UGGShieldSet::PostAttributeChange(const FGameplayAttribute& Attribute, float OldValue, float NewValue)
 {
 	Super::PostAttributeChange(Attribute, OldValue, NewValue);
+
+	if (Attribute == GetMaxShieldAttribute())
+	{
+		if (GetShield() > NewValue)
+		{
+			ULyraAbilitySystemComponent* ASC = GetLyraAbilitySystemComponent();
+			check(ASC);
+			ASC->ApplyModToAttribute(GetShieldAttribute(), EGameplayModOp::Override, NewValue);
+		}
+	}
 }
 
 void UGGShieldSet::ClampAttribute(const FGameplayAttribute& Attribute, float& NewValue) const
 {
+	if (Attribute == GetShieldAttribute())
+	{
+		NewValue = FMath::Clamp(NewValue, 0.0f, GetMaxShield());
+	}
+	else if (Attribute == GetMaxShieldAttribute())
+	{
+		NewValue = FMath::Max(NewValue, 1.0f);
+	}
 }

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Executions/GGDamageExecution.cpp
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Executions/GGDamageExecution.cpp
@@ -183,14 +183,14 @@ void UGGDamageExecution::Execute_Implementation(const FGameplayEffectCustomExecu
 
 		// 보호막에 가해질 데미지 적용
 		OutExecutionOutput.AddOutputModifier(FGameplayModifierEvaluatedData(
-			UGGShieldSet::GetShieldDamageAttribute(), EGameplayModOp::Override, DamageToShield));
+			UGGShieldSet::GetShieldDamageAttribute(), EGameplayModOp::Additive, DamageToShield));
 	}
 
 	// 체력에 가해질 데미지 적용
 	if (DamageToHealth > 0.f)
 	{
 		OutExecutionOutput.AddOutputModifier(FGameplayModifierEvaluatedData(
-			ULyraHealthSet::GetDamageAttribute(), EGameplayModOp::Override, DamageToHealth));
+			ULyraHealthSet::GetDamageAttribute(), EGameplayModOp::Additive, DamageToHealth));
 	}
 
 #endif

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Executions/GGDamageExecution.cpp
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/AbilitySystem/Executions/GGDamageExecution.cpp
@@ -183,9 +183,9 @@ void UGGDamageExecution::Execute_Implementation(const FGameplayEffectCustomExecu
 
 		// 보호막에 가해질 데미지 적용
 		OutExecutionOutput.AddOutputModifier(FGameplayModifierEvaluatedData(
-				UGGShieldSet::GetShieldDamageAttribute(), EGameplayModOp::Override, -DamageToShield));
+			UGGShieldSet::GetShieldDamageAttribute(), EGameplayModOp::Override, DamageToShield));
 	}
-	
+
 	// 체력에 가해질 데미지 적용
 	if (DamageToHealth > 0.f)
 	{

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/Player/GGPlayerState.cpp
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/Player/GGPlayerState.cpp
@@ -6,6 +6,7 @@
 #include "AbilitySystem/Attributes/GGDefenseSet.h"
 #include "AbilitySystem/Attributes/GGOffenseSet.h"
 #include "AbilitySystem/Attributes/GGResourceSet.h"
+#include "AbilitySystem/Attributes/GGShieldSet.h"
 #include "AbilitySystem/Attributes/GGUtilitySet.h"
 
 AGGPlayerState::AGGPlayerState(const FObjectInitializer& ObjectInitializer)
@@ -15,4 +16,5 @@ AGGPlayerState::AGGPlayerState(const FObjectInitializer& ObjectInitializer)
 	OffenseSet = CreateDefaultSubobject<UGGOffenseSet>(TEXT("OffenseSet"));
 	DefenseSet = CreateDefaultSubobject<UGGDefenseSet>(TEXT("DefenseSet"));
 	UtilitySet = CreateDefaultSubobject<UGGUtilitySet>(TEXT("UtilitySet"));
+	ShieldSet = CreateDefaultSubobject<UGGShieldSet>(TEXT("ShieldSet"));
 }

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/AbilitySystem/Attributes/GGShieldSet.h
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/AbilitySystem/Attributes/GGShieldSet.h
@@ -1,0 +1,52 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "AbilitySystemComponent.h"
+#include "AbilitySystem/Attributes/LyraAttributeSet.h"
+#include "GGShieldSet.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class GGCORERUNTIME_API UGGShieldSet : public ULyraAttributeSet
+{
+	GENERATED_BODY()
+
+public:
+	
+	UGGShieldSet();
+
+	ATTRIBUTE_ACCESSORS(UGGShieldSet, Shield);
+	ATTRIBUTE_ACCESSORS(UGGShieldSet, MaxShield);
+	
+	mutable FLyraAttributeEvent OnShieldChanged;
+	mutable FLyraAttributeEvent OnMaxShieldChanged;
+
+protected:
+
+	UFUNCTION()
+	virtual void OnRep_Shield(const FGameplayAttributeData& OldValue);
+
+	UFUNCTION()
+	virtual void OnRep_MaxShield(const FGameplayAttributeData& OldValue);
+
+	virtual bool PreGameplayEffectExecute(FGameplayEffectModCallbackData& Data) override;
+	virtual void PostGameplayEffectExecute(const FGameplayEffectModCallbackData& Data) override;
+
+	virtual void PreAttributeBaseChange(const FGameplayAttribute& Attribute, float& NewValue) const override;
+	virtual void PreAttributeChange(const FGameplayAttribute& Attribute, float& NewValue) override;
+	virtual void PostAttributeChange(const FGameplayAttribute& Attribute, float OldValue, float NewValue) override;
+
+	void ClampAttribute(const FGameplayAttribute& Attribute, float& NewValue) const;
+
+public:
+
+	UPROPERTY(BlueprintReadOnly, ReplicatedUsing = OnRep_Shield, Category = "GG|Shield", Meta = (DisplayName = "보호막", AllowPrivateAccess = true))
+	FGameplayAttributeData Shield;
+	
+	UPROPERTY(BlueprintReadOnly, ReplicatedUsing = OnRep_MaxShield, Category = "GG|Shield", Meta = (DisplayName = "보호막", AllowPrivateAccess = true))
+	FGameplayAttributeData MaxShield;
+	
+};

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/AbilitySystem/Attributes/GGShieldSet.h
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/AbilitySystem/Attributes/GGShieldSet.h
@@ -19,19 +19,15 @@ public:
 	UGGShieldSet();
 
 	ATTRIBUTE_ACCESSORS(UGGShieldSet, Shield);
-	ATTRIBUTE_ACCESSORS(UGGShieldSet, MaxShield);
 	ATTRIBUTE_ACCESSORS(UGGShieldSet, ShieldDamage);
+	ATTRIBUTE_ACCESSORS(UGGShieldSet, ShieldHealing);
 	
 	mutable FLyraAttributeEvent OnShieldChanged;
-	mutable FLyraAttributeEvent OnMaxShieldChanged;
 
 protected:
 
 	UFUNCTION()
 	virtual void OnRep_Shield(const FGameplayAttributeData& OldValue);
-
-	UFUNCTION()
-	virtual void OnRep_MaxShield(const FGameplayAttributeData& OldValue);
 
 	virtual bool PreGameplayEffectExecute(FGameplayEffectModCallbackData& Data) override;
 	virtual void PostGameplayEffectExecute(const FGameplayEffectModCallbackData& Data) override;
@@ -46,13 +42,12 @@ public:
 	UPROPERTY(BlueprintReadOnly, ReplicatedUsing = OnRep_Shield, Category = "GG|Shield", Meta = (DisplayName = "보호막", AllowPrivateAccess = true))
 	FGameplayAttributeData Shield;
 	
-	UPROPERTY(BlueprintReadOnly, ReplicatedUsing = OnRep_MaxShield, Category = "GG|Shield", Meta = (DisplayName = "보호막", AllowPrivateAccess = true))
-	FGameplayAttributeData MaxShield;
-	
 	float ShieldBeforeAttributeChange;
-	float MaxShieldBeforeAttributeChange;
 
 	UPROPERTY(BlueprintReadOnly, Category = "GG|Shield", Meta = (AllowPrivateAccess = true))
 	FGameplayAttributeData ShieldDamage;
+	
+	UPROPERTY(BlueprintReadOnly, Category = "GG|Shield", Meta = (AllowPrivateAccess = true))
+	FGameplayAttributeData ShieldHealing;
 	
 };

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/AbilitySystem/Attributes/GGShieldSet.h
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/AbilitySystem/Attributes/GGShieldSet.h
@@ -20,6 +20,7 @@ public:
 
 	ATTRIBUTE_ACCESSORS(UGGShieldSet, Shield);
 	ATTRIBUTE_ACCESSORS(UGGShieldSet, MaxShield);
+	ATTRIBUTE_ACCESSORS(UGGShieldSet, ShieldDamage);
 	
 	mutable FLyraAttributeEvent OnShieldChanged;
 	mutable FLyraAttributeEvent OnMaxShieldChanged;
@@ -35,7 +36,6 @@ protected:
 	virtual bool PreGameplayEffectExecute(FGameplayEffectModCallbackData& Data) override;
 	virtual void PostGameplayEffectExecute(const FGameplayEffectModCallbackData& Data) override;
 
-	virtual void PreAttributeBaseChange(const FGameplayAttribute& Attribute, float& NewValue) const override;
 	virtual void PreAttributeChange(const FGameplayAttribute& Attribute, float& NewValue) override;
 	virtual void PostAttributeChange(const FGameplayAttribute& Attribute, float OldValue, float NewValue) override;
 
@@ -48,5 +48,11 @@ public:
 	
 	UPROPERTY(BlueprintReadOnly, ReplicatedUsing = OnRep_MaxShield, Category = "GG|Shield", Meta = (DisplayName = "보호막", AllowPrivateAccess = true))
 	FGameplayAttributeData MaxShield;
+	
+	float ShieldBeforeAttributeChange;
+	float MaxShieldBeforeAttributeChange;
+
+	UPROPERTY(BlueprintReadOnly, Category = "GG|Shield", Meta = (AllowPrivateAccess = true))
+	FGameplayAttributeData ShieldDamage;
 	
 };

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/Player/GGPlayerState.h
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/Player/GGPlayerState.h
@@ -32,4 +32,7 @@ private:
 	UPROPERTY()
 	TObjectPtr<const class UGGUtilitySet> UtilitySet;
 
+	UPROPERTY()
+	TObjectPtr<const class UGGShieldSet> ShieldSet;
+
 };


### PR DESCRIPTION
### 요약

이 풀 리퀘스트는 플레이어 방어막을 관리하기 위한 새로운 GGShieldSet을 도입하고, 방어막 피해 로직을 시스템에 통합합니다. 주요 변경 사항은 다음과 같습니다:

- 런타임 접근을 위한 UPROPERTY 지원과 함께 방어막 관련 속성을 관리하는 GGShieldSet 추가.

- GGDamageExecution을 개선하여 방어막 우선 피해 계산을 통합.

- ShieldDamage 속성과 방어막 피해 및 클램핑 처리를 위한 post-effect 실행 로직 추가.

- 더 나은 캡슐화와 값 관리를 위해 사전/사후 속성 수정 함수 개선.

- 방어막과 체력이 이제 변경 사항을 브로드캐스트하고, 최종 피해 계산 후 수정자를 적용.

- 최대 방어막 값을 강제하기 위해 ClampAttribute 메서드를 확장하고, 방어막 속성에 대한 복제 지원 추가.

- PlayerState에 ShieldSet 연결.