### PR TITLE
버프/디버프 UI 향상 및 ESC키 활성화

### DIFF
--- a/Plugins/GameFeatures/GGCore/Config/Tags/GGCoreTags.ini
+++ b/Plugins/GameFeatures/GGCore/Config/Tags/GGCoreTags.ini
@@ -32,4 +32,5 @@ GameplayTagList=(Tag="State.Buff.Test.9",DevComment="")
 GameplayTagList=(Tag="State.Buff.Test.10",DevComment="")
 GameplayTagList=(Tag="State.Debuff",DevComment="")
 GameplayTagList=(Tag="State.Debuff.Test",DevComment="")
+GameplayTagList=(Tag="State.Debuff.Test.2",DevComment="")
 

--- a/Plugins/GameFeatures/GGCore/Content/UserInterface/W_GGHUDLayout.uasset
+++ b/Plugins/GameFeatures/GGCore/Content/UserInterface/W_GGHUDLayout.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b4e9966bc5bcb921eeb554ebf0d812b7b866d06b9f94394d927ab55565ad7a3b
-size 49332
+oid sha256:bc77739e37ee7619657fac875ad0efc4eccd438be4c691f6fc13d9dbd68f003d
+size 48401

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/UI/GGBuffContainerWidget.cpp
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Private/UI/GGBuffContainerWidget.cpp
@@ -102,6 +102,7 @@ void UGGBuffContainerWidget::AddEffect(const FGGStatusEffectMessage& EffectMessa
 		DisplayData.RemainingDuration = EffectMessage.RemainingTime;
 		DisplayData.TotalDuration = EffectMessage.Duration;
 		DisplayData.bIsActive = true;
+		DisplayData.bIsBuff = EffectMessage.bIsBuff;
 
 		ExistingSlot->SetBuffData(DisplayData);
 
@@ -165,8 +166,6 @@ void UGGBuffContainerWidget::ClearAllEffects()
 
 bool UGGBuffContainerWidget::ShouldHandleTag(const FGameplayTag& Tag) const
 {
-	// 정확히 일치하거나 하위 태그인 경우
-	// return HandledTags.HasTag(Tag) || HandledTags.HasTagExact(Tag.RequestDirectParent());
 	// HandledTags의 각 태그에 대해 하위 태그인지 확인
 	for (const FGameplayTag& HandledTag : HandledTags)
 	{
@@ -283,6 +282,7 @@ UGGBuffSlotWidget* UGGBuffContainerWidget::CreateEffectSlot(const FGGStatusEffec
 	DisplayData.RemainingDuration = EffectMessage.RemainingTime;
 	DisplayData.TotalDuration = EffectMessage.Duration;
 	DisplayData.bIsActive = true;
+	DisplayData.bIsBuff = EffectMessage.bIsBuff;
 
 	NewSlot->SetBuffData(DisplayData);
 
@@ -373,6 +373,7 @@ void UGGBuffContainerWidget::OnGameplayEffectAdded(UAbilitySystemComponent* ASC,
 		EffectMessage.Duration = Spec.GetDuration();
 		EffectMessage.RemainingTime = Spec.GetDuration();
 		EffectMessage.bIsActive = true;
+		EffectMessage.bIsBuff = !EffectTag.ToString().Contains("Debuff");
 
 		AddEffect(EffectMessage);
 	}

--- a/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/UI/GGBuffContainerWidget.h
+++ b/Plugins/GameFeatures/GGCore/Source/GGCoreRuntime/Public/UI/GGBuffContainerWidget.h
@@ -30,12 +30,16 @@ struct FGGStatusEffectMessage
 	UPROPERTY(BlueprintReadOnly)
 	bool bIsActive = true;
 
+	UPROPERTY(BlueprintReadOnly)
+	bool bIsBuff = true;
+
 	FGGStatusEffectMessage()
 	{
 		EffectTag = FGameplayTag::EmptyTag;
 		Duration = 0.0f;
 		RemainingTime = 0.0f;
 		bIsActive = true;
+		bIsBuff = true;
 	}
 };
 
@@ -69,10 +73,6 @@ protected:
 	/** 이펙트 슬롯 위젯 클래스 */
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "StatusEffect")
 	TSubclassOf<UGGBuffSlotWidget> EffectSlotWidgetClass;
-
-	/** 이펙트 아이콘 데이터 에셋 */
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "StatusEffect")
-	TObjectPtr<UGGBuffIconDataAsset> EffectIconDataAsset;
 
 	/** 최대 표시할 이펙트 개수 */
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "StatusEffect", meta = (ClampMin = "1", ClampMax = "20"))


### PR DESCRIPTION
### 변경 사항 설명

- **게임플레이 태그 업데이트**:
    - 테스트 목적으로 애셋에 `State.Debuff.Test.2` 게임플레이 태그를 추가했습니다.

- **HUD 기능**:
    - `W_GGHUDLayout` 애셋에서 Esc 키로 게임 메뉴를 열 수 있도록 활성화했습니다.
    - 다음과 같은 커스터마이징 옵션들을 추가했습니다:
        - `Is Back Handler`: ESC 키 비활성화 기능을 토글합니다.
        - `Is Back Action Displayed in Action Bar`: ESC 키가 게임 메뉴를 열지 여부를 결정합니다.
        - `Escape Menu`: ESC 키를 눌렀을 때 열릴 위젯을 지정합니다.

- **버프/디버프 시스템 개선**:
    - 테두리 색상을 구분하기 위해 `FGGStatusEffectMessage`에 `bIsBuff` 속성을 추가했습니다.
    - `EffectMessage`에서 디버프를 감지하는 로직을 구현했습니다.
    - `UGGBuffContainerWidget` 개선사항:
        - 태그 처리 로직을 단순화했습니다.
        - 불필요한 코드와 주석을 제거하여 가독성을 향상시켰습니다.
    - 슬롯 데이터 업데이트를 개선하여 `bIsBuff` 속성을 정확히 포함하도록 했습니다.